### PR TITLE
Issue 9 - attribute for all component group element names

### DIFF
--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -511,7 +511,9 @@ def component_group(ref):
     """
     @property
     def wrapper(self): #pylint: disable=missing-docstring
-        return Resource(**{
-            element: Element(self.controller, selector) \
-                for element, selector in iteritems(ref(self))})
+        group = iteritems(ref(self))
+        resource = Resource(**{
+            element: Element(self.controller, selector) for element, selector in group})
+        resource.__group__ = [element for element, _ in group]
+        return resource
     return wrapper

--- a/tests/test_component_elements.py
+++ b/tests/test_component_elements.py
@@ -23,9 +23,11 @@ class TestElement(BaseTest):
     def test_element_group(self):
         """test element groups are generated as intended"""
         self.assertIsInstance(self.social_buttons, Resource)
-        for s in ('twitter', 'facebook', 'linkedin'):
-            self.assertTrue(hasattr(self.social_buttons, s))
-            self.assertIsInstance(getattr(self.social_buttons, s), Element)
+        expected_attributes = ('twitter', 'facebook', 'linkedin')
+        self.assertTrue(all(item in expected_attributes for item in self.social_buttons.__group__))
+        for sb in expected_attributes:
+            self.assertTrue(hasattr(self.social_buttons, sb))
+            self.assertIsInstance(getattr(self.social_buttons, sb), Element)
 
     def test_element_wrapper(self):
         """test element wrapper instantiated as intended"""


### PR DESCRIPTION
In this pull request I've included a new attribute to the component group resource, `__group__`, that contains an iterable list of component group element names.