### PR TITLE
Issue 7 - mouseup and mousedown

### DIFF
--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -154,7 +154,7 @@ If you require the traditional clicking behavior, simplify fetch a selenium WebE
 
     component.button.get().click()
 
-Additionally, not elements that do not listen on the click event but rather mouseup or mousedown, you may refer to the api methods `mouseup` and `mousedown` (chainable).
+Additionally, for elements that do not listen on the click event but rather mouseup or mousedown, you may refer to the api methods `mouseup` and `mousedown` (chainable):
 
 .. code-block:: python
 

--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -154,6 +154,14 @@ If you require the traditional clicking behavior, simplify fetch a selenium WebE
 
     component.button.get().click()
 
+Additionally, not elements that do not listen on the click event but rather mouseup or mousedown, you may refer to the api methods `mouseup` and `mousedown` (chainable).
+
+.. code-block:: python
+
+    component.button\
+        .mouseup()\
+        .mousedown()
+
 Scrolling To an Element
 -----------------------
 

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -154,6 +154,20 @@ class Element(Resource):
             return self
         return None
 
+    def mouseup(self):
+        """
+        :Description: Dispatches a mouseup event on the given element.
+        :return: Element, None
+        """
+        return self.trigger_event('mouseup', 'MouseEvent')
+
+    def mousedown(self):
+        """
+        :Description: Dispatches a mousedown event on the given element.
+        :return: Element, None
+        """
+        return self.trigger_event('mousedown', 'MouseEvent')
+
     def scroll_to(self):
         """
         :Description: Scroll to the given element.

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -159,14 +159,16 @@ class Element(Resource):
         :Description: Dispatches a mouseup event on the given element.
         :return: Element, None
         """
-        return self.trigger_event('mouseup', 'MouseEvent')
+        # ignoring from coverage, assume covered by trigger_event test
+        return self.trigger_event('mouseup', 'MouseEvent') # pragma: no cover
 
     def mousedown(self):
         """
         :Description: Dispatches a mousedown event on the given element.
         :return: Element, None
         """
-        return self.trigger_event('mousedown', 'MouseEvent')
+        # ignoring from coverage, assume covered by trigger_event test
+        return self.trigger_event('mousedown', 'MouseEvent') # pragma: no cover
 
     def scroll_to(self):
         """


### PR DESCRIPTION
In this pull request I've added the support for two shorthand Element methods, `mouseup` and `mousedown`.

Related issues: [Issue 7](https://github.com/neetjn/py-component-controller/issues/7)