### PR TITLE
Issue 20

### DIFF
--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -405,6 +405,11 @@ A helpful feature of the elements wrapper, is the ability to wait for a number o
     component.users.wait_for(5, length=3,
         error="Expected at least 3 users to be available within 5 seconds")
 
+    # by default, wait_for will wait for the number of specified elements to be present
+    # to execute a strict wait on length, you may use the strict flag
+    component.users.wait_for(5, length=5, strict=True,
+        error="Expected 5 users to be available within 5 seconds")
+
 Waiting For Visibility of Elements
 ----------------------------------
 

--- a/pyscc/controller.py
+++ b/pyscc/controller.py
@@ -75,18 +75,9 @@ class Controller(object):
         webdriver.find_elements_by_css_selector = MethodType(lambda self, selector:\
             safari_selector_patch(by_css_selector, selector), webdriver)
 
-<<<<<<< HEAD
         by_xpath = webdriver.find_elements_by_xpath
         webdriver.find_elements_by_xpath = MethodType(lambda self, selector: safari_selector_patch(
             by_xpath, selector), webdriver)
-=======
-            for method in methods:
-                complete_method_name = 'find_elements_by_{method}'.format(method=method)
-                method = getattr(webdriver, complete_method_name)
-                setattr(webdriver, complete_method_name, MethodType(
-                    lambda self, selector: _safari_patch(executor=method, selector=selector), # pylint: disable=cell-var-from-loop
-                    webdriver))
->>>>>>> master
 
         return webdriver
 


### PR DESCRIPTION
I've included examples in the docs pertaining to the strict flag for the `wait_for` method of the Elements wrapper.

Related issue: [Issue 20](https://github.com/neetjn/py-component-controller/issues/20)