### PR TITLE
Issue 33 - Template Formatting

### DIFF
--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -330,7 +330,7 @@ Take for example the following component elements provider:
 
     @component_elements
     def users(self):
-        return 'a.users.{class}'
+        return 'a.users.${class}'
 
 You can format the element's selector prior to executing any operations.
 

--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -47,7 +47,7 @@ Take for example the following component element provider:
 
     @component_element
     def button(self):
-        return 'button[ng-click="{method}"]'
+        return 'button[ng-click="${method}"]'
 
 You can format the element's selector prior to executing any operations.
 
@@ -450,10 +450,10 @@ several elements that are a child of the task's container. This can be converted
     @component_group
     def task(self):
         return {
-            'checkbox': 'todo-task#{id} input[type="checkbox"]',
-            'title': 'todo-task#{id} span#title',
-            'created': 'todo-task#{id} span#created',
-            'assignee': 'todo-task#{id} a#assignee'
+            'checkbox': 'todo-task#${id} input[type="checkbox"]',
+            'title': 'todo-task#${id} span#title',
+            'created': 'todo-task#${id} span#created',
+            'assignee': 'todo-task#${id} a#assignee'
         }
 
     ...

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from string import Template
 from types import MethodType
 from selenium.common.exceptions import NoSuchElementException, ElementNotVisibleException, \
     InvalidSelectorException
@@ -54,7 +55,7 @@ class Element(Resource):
         :Description: Used to format selectors.
         :return: Element
         """
-        self.selector = self._selector.format(**kwargs)
+        self.selector = Template(self._selector).safe_substitute(**kwargs)
         return self
 
     def get(self):
@@ -391,7 +392,7 @@ class Elements(Resource):
         :Description: Used to format selectors.
         :return: Elements
         """
-        self.selector = self._selector.format(**kwargs)
+        self.selector = Template(self._selector).safe_substitute(**kwargs)
         return self
 
     def get(self):
@@ -545,11 +546,8 @@ def component_group(ref):
         # pylint: disable=C0103, W0212
         for element in self.__group__:
             el = getattr(self, element)
-            try:
-                el._selector = el._selector.format(**kwargs)
-                el.selector = el._selector
-            except KeyError:
-                pass
+            el._selector = Template(el._selector).safe_substitute(**kwargs)
+            el.selector = el._selector
         return self
 
     @property

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ class HomePage(Component):
 
     @component_element
     def task(self):
-        return 'todo-task#task-{id}'
+        return 'todo-task#task-${id}'
 
     @component_elements
     def tasks(self):
@@ -62,9 +62,9 @@ class HomePage(Component):
     @component_group
     def task_form(self):
         return {
-            'assignee': '{form} #taskAssignee',
-            'title': '{form} #taskTitle.{{class_name}}',
-            'content': '{form} #taskContent'
+            'assignee': '${form} #taskAssignee',
+            'title': '${form} #taskTitle.${class_name}',
+            'content': '${form} #taskContent'
         }
 
 


### PR DESCRIPTION
In this pull request, I've migrated the previous selector formatting logic to use the Template class rather than Formatter. This will allow us to use nested formats with component groups.

Related Issue: [Issue 33](https://github.com/neetjn/py-component-controller/issues/33)