### PR TITLE
Issue 87 - Component root selector.

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -15,6 +15,8 @@ The following code is an example of a controller for Google's search engine:
 
     class Home(Component):
 
+        _ = 'body > app'  # optional root selector to be applied to all component items
+
         @component_element
         def search_bar(self):
             # we only need to return the selector

--- a/pyscc/component.py
+++ b/pyscc/component.py
@@ -44,8 +44,8 @@ class Component(Resource): # pylint: disable=too-few-public-methods
         base_attributes = [child for child in dir(self) if not child.startswith('_') and child not in expected_attributes]
         element_instances = [el for el in base_attributes if isinstance(getattr(self, el), Element)]
         elements_instances = [el for el in base_attributes if isinstance(getattr(self, el), Elements)]
-        group_instances = [el for el in base_attributes if el
-            not in element_instances + elements_instances and isinstance(getattr(self, el), Resource)]
+        # pylint: disable=line-too-long
+        group_instances = [el for el in base_attributes if el not in element_instances + elements_instances and isinstance(getattr(self, el), Resource)]
         return {
             'element': element_instances,
             'elements': elements_instances,

--- a/pyscc/component.py
+++ b/pyscc/component.py
@@ -36,15 +36,17 @@ class Component(Resource): # pylint: disable=too-few-public-methods
     @property
     def __describe__(self):
         """
-        Fetch component description with attribute names for Element, Elements, and Component Group instances.
+        Fetch component description with attribute names for Element, Elements,
+        and Component Group instances.
 
+        :example: { 'element': [...], 'elements': [...], 'group': [...] }
         :return: dict
         """
+        # pylint: disable=line-too-long
         expected_attributes = ['controller', 'browser', 'env', 'validate']
         base_attributes = [child for child in dir(self) if not child.startswith('_') and child not in expected_attributes]
         element_instances = [el for el in base_attributes if isinstance(getattr(self, el), Element)]
         elements_instances = [el for el in base_attributes if isinstance(getattr(self, el), Elements)]
-        # pylint: disable=line-too-long
         group_instances = [el for el in base_attributes if el not in element_instances + elements_instances and isinstance(getattr(self, el), Resource)]
         return {
             'element': element_instances,

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -40,7 +40,7 @@ class Element(Resource):
     def __init__(self, controller, component, selector):
         self.controller = controller
         self.component = component
-        if self.component._:
+        if hasattr(self.component, '_'):
             selector = self.component._ + ' ' + selector
         self.selector = self._selector = selector
         self.check = Check(self)
@@ -424,7 +424,7 @@ class Elements(Resource):
     def __init__(self, controller, component, selector):
         self.controller = controller
         self.component = component
-        if self.component._:
+        if hasattr(self.component, '_'):
             selector = self.component._ + ' ' + selector
         self.selector = self._selector = selector
         self.checks = Checks(self)

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -32,11 +32,16 @@ class Element(Resource):
 
     :param controller: Parent controller reference.
     :type controller: Controller
+    :param component: Element's component instance.
+    :type component: Component
     :param selector: Selector of given element.
     :type selector: string
     """
-    def __init__(self, controller, selector):
+    def __init__(self, controller, component, selector):
         self.controller = controller
+        self.component = component
+        if self.component._:
+            selector = self.component._ + ' ' + selector
         self.selector = self._selector = selector
         self.check = Check(self)
         self.wait_handle = None  # used for js waits
@@ -411,11 +416,16 @@ class Elements(Resource):
 
     :param controller: Parent controller reference.
     :type controller: Controller
+    :param component: Elements' component instance.
+    :type component: Component
     :param selector: Selector of given elements.
     :type selector: string
     """
-    def __init__(self, controller, selector):
+    def __init__(self, controller, component, selector):
         self.controller = controller
+        self.component = component
+        if self.component._:
+            selector = self.component._ + ' ' + selector
         self.selector = self._selector = selector
         self.checks = Checks(self)
         self.validate()
@@ -907,7 +917,7 @@ def component_element(ref):
     """
     @property
     def wrapper(self):  # pylint: disable=missing-docstring
-        return Element(self.controller, ref(self))
+        return Element(self.controller, self, ref(self))
     return wrapper
 
 
@@ -919,7 +929,7 @@ def component_elements(ref):
     """
     @property
     def wrapper(self):  # pylint: disable=missing-docstring
-        return Elements(self.controller, ref(self))
+        return Elements(self.controller, self, ref(self))
     return wrapper
 
 
@@ -941,7 +951,7 @@ def component_group(ref):
     def wrapper(self): # pylint: disable=missing-docstring
         group_def = ref(self)
         # pylint: disable=line-too-long
-        group = Resource(**{element: Element(self.controller, (group_def.get('_') + ' ' + selector) if \
+        group = Resource(**{element: Element(self.controller, self, (group_def.get('_') + ' ' + selector) if \
             group_def.get('_') else selector) for element, selector in iteritems(group_def) \
             if selector != '_'})
         group.__group__ = [element for element, _ in iteritems(group_def) if element != '_']

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -24,6 +24,13 @@ class TestComponent(BaseTest):
         self.assertEqual(self.app.components.home.env, self.app.env)
         self.assertEqual(self.app.components.home.env.created, self.created)
 
+    def test_component_root_selector(self):
+        """test component root selector applies to element, elements, and group"""
+        home = self.app.components.home
+        self.assertTrue(home.logo.selector.startswith('body '))
+        self.assertTrue(home.task_group.desc.selector.startswith('body '))
+        self.assertTrue(home.task_assignees.selector.startswith('body '))
+
     def test_component_description(self):
         """test component description works as intended"""
         description = self.app.components.home.__describe__

--- a/tests/test_component_elements.py
+++ b/tests/test_component_elements.py
@@ -44,15 +44,15 @@ class TestElement(BaseTest):
     def test_element_group_fmt(self):
         """test element groups format selectors as intended"""
         self.assertEqual(self.task_form.fmt(form='create-todo'), self.task_form)
-        self.assertEqual(self.task_form.assignee.selector, 'create-todo #taskAssignee')
+        self.assertEqual(self.task_form.assignee.selector, 'body create-todo #taskAssignee')
         self.task_form.title.fmt(class_name='u-full-width')
-        self.assertEqual(self.task_form.title.selector, 'create-todo #taskTitle.u-full-width')
+        self.assertEqual(self.task_form.title.selector, 'body create-todo #taskTitle.u-full-width')
 
     def test_element_group_root(self):
         """test element group root element"""
         self.assertTrue('_' not in self.task_group.__group__)  # gh issue 54
         task = self.task_group.fmt(id='1')
-        self.assertEqual(task.desc.selector, 'todo-task#task-1 h4')
+        self.assertEqual(task.desc.selector, 'body todo-task#task-1 h4')
 
     def test_element_wrapper(self):
         """test element wrapper instantiated as intended"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,6 +23,8 @@ class Header(Component):
 
 class HomePage(Component):
 
+    _ = 'body'
+
     @component_element
     def logo(self):
         return 'header-partial h1.logo'


### PR DESCRIPTION
### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

Yes.

2. Can you provide an example of your patch in use?

Provided in docs.

3. Is this a breaking change?

No.

#### Content

Provide a short description about what you have changed:

I've added support for root selectors in Component instances. This functionality follows the following notation:

```python
class Home(Component):

  _ = 'body > app'

  @component_element
  def button(self):
    # selector will be evaluated as "body > app button.btn-green"
    return 'button.btn-green'
```
