### PR TITLE
Issue 92 - Elements Stale Checks

### DIFF
--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -25,7 +25,7 @@ from pyscc.controller import Controller
 from pyscc.resource import Resource
 
 
-ELEMENTS_GETTER_WAIT_TIME = 3
+ELEMENTS_STALE_WAIT_TIME = 3
 
 
 # pylint: disable=too-many-public-methods
@@ -443,6 +443,11 @@ class Elements(Resource):
         return self.controller.browser.find_elements_by_css_selector(self.selector) \
             or self.controller.browser.find_elements_by_xpath(self.selector)
 
+    def __wait_elements_not_stale(self, timeout):
+        self.controller.wait(
+            timeout=ELEMENTS_GETTER_WAIT_TIME,
+            condition=lambda: [element.text for element in self.get()])
+
     def fmt(self, **kwargs):
         """
         Used to format selectors.
@@ -480,9 +485,7 @@ class Elements(Resource):
         """
         if check_stale_element:
             # wait in the event element list is actively loading
-            self.controller.wait(
-                timeout=ELEMENTS_GETTER_WAIT_TIME,
-                condition=lambda: [element.text for element in self.get()])
+            self.__wait_elements_not_stale(ELEMENTS_STALE_WAIT_TIME)
         found = self.get()
         if found:
             collection = []
@@ -505,9 +508,7 @@ class Elements(Resource):
         """
         if check_stale_element:
             # wait in the event element list is actively loading
-            self.controller.wait(
-                timeout=ELEMENTS_GETTER_WAIT_TIME,
-                condition=lambda: [element.text for element in self.get()])
+            self.__wait_elements_not_stale(ELEMENTS_STALE_WAIT_TIME)
         return [self.controller.js.get_value(element) for element in self.get()]
 
     def get_attribute(self, attribute, check_stale_element=False):
@@ -522,9 +523,7 @@ class Elements(Resource):
         """
         if check_stale_element:
             # wait in the event element list is actively loading
-            self.controller.wait(
-                timeout=ELEMENTS_GETTER_WAIT_TIME,
-                condition=lambda: [element.text for element in self.get()])
+            self.__wait_elements_not_stale(ELEMENTS_STALE_WAIT_TIME)
         return [self.controller.js.get_attribute(element, attribute) for element in self.get()]
 
     def set_attribute(self, attribute, value):
@@ -553,9 +552,7 @@ class Elements(Resource):
         """
         if check_stale_element:
             # wait in the event element list is actively loading
-            self.controller.wait(
-                timeout=ELEMENTS_GETTER_WAIT_TIME,
-                condition=lambda: [element.text for element in self.get()])
+            self.__wait_elements_not_stale(ELEMENTS_STALE_WAIT_TIME)
         return [self.controller.js.get_property(element, prop) for element in self.get()]
 
     def set_property(self, prop, value):

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -25,7 +25,6 @@ from pyscc.controller import Controller
 from pyscc.resource import Resource
 
 
-ELEMENT_GETTER_WAIT_TIME = 3
 ELEMENTS_GETTER_WAIT_TIME = 3
 
 

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -444,9 +444,8 @@ class Elements(Resource):
             or self.controller.browser.find_elements_by_xpath(self.selector)
 
     def __wait_elements_not_stale(self, timeout):
-        self.controller.wait(
-            timeout=ELEMENTS_GETTER_WAIT_TIME,
-            condition=lambda: [element.text for element in self.get()])
+        # pylint: disable=line-too-long
+        self.controller.wait(timeout, condition=lambda: [element.text for element in self.get()])
 
     def fmt(self, **kwargs):
         """

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -473,6 +473,8 @@ class Elements(Resource):
         :type raw: bool
         :return: [string, ...], None
         """
+        if not self.controller.wait(timeout=3, condition=lambda: [element.text for element in self.get()]):
+            return []
         found = self.get()
         if found:
             collection = []

--- a/pyscc/element.py
+++ b/pyscc/element.py
@@ -25,6 +25,10 @@ from pyscc.controller import Controller
 from pyscc.resource import Resource
 
 
+ELEMENT_GETTER_WAIT_TIME = 3
+ELEMENTS_GETTER_WAIT_TIME = 3
+
+
 # pylint: disable=too-many-public-methods
 class Element(Resource):
     """
@@ -465,16 +469,21 @@ class Elements(Resource):
         """
         return len(self.get())
 
-    def text(self, raw=False):
+    def text(self, raw=False, check_stale_element=False):
         """
         Get list of element text values.
 
         :param raw: Extract inner html from element.
         :type raw: bool
+        :param check_stale_element: Ensure retrieved WebElement instances are finished mounting.
+        :type check_stale_element: bool
         :return: [string, ...], None
         """
-        if not self.controller.wait(timeout=3, condition=lambda: [element.text for element in self.get()]):
-            return []
+        if check_stale_element:
+            # wait in the event element list is actively loading
+            self.controller.wait(
+                timeout=ELEMENTS_GETTER_WAIT_TIME,
+                condition=lambda: [element.text for element in self.get()])
         found = self.get()
         if found:
             collection = []
@@ -487,22 +496,36 @@ class Elements(Resource):
             return collection
         return []
 
-    def value(self):
+    def value(self, check_stale_element=False):
         """
         Get list of input element values.
 
+        :param check_stale_element: Ensure retrieved WebElement instances are finished mounting.
+        :type check_stale_element: bool
         :return: [string, ...], None
         """
+        if check_stale_element:
+            # wait in the event element list is actively loading
+            self.controller.wait(
+                timeout=ELEMENTS_GETTER_WAIT_TIME,
+                condition=lambda: [element.text for element in self.get()])
         return [self.controller.js.get_value(element) for element in self.get()]
 
-    def get_attribute(self, attribute):
+    def get_attribute(self, attribute, check_stale_element=False):
         """
         Used to fetch list of elements attributes.
 
         :param attribute: Attribute of elements to target.
         :type attribute: string
+        :param check_stale_element: Ensure retrieved WebElement instances are finished mounting.
+        :type check_stale_element: bool
         :return: [(None, bool, int, float, string), ...]
         """
+        if check_stale_element:
+            # wait in the event element list is actively loading
+            self.controller.wait(
+                timeout=ELEMENTS_GETTER_WAIT_TIME,
+                condition=lambda: [element.text for element in self.get()])
         return [self.controller.js.get_attribute(element, attribute) for element in self.get()]
 
     def set_attribute(self, attribute, value):
@@ -519,14 +542,21 @@ class Elements(Resource):
             self.controller.js.set_attribute(element, attribute, value)
         return self
 
-    def get_property(self, prop):
+    def get_property(self, prop, check_stale_element=False):
         """
         Used to fetch list of elements properties.
 
         :param prop: Property of elements to target.
         :type prop: string
+        :param check_stale_element: Ensure retrieved WebElement instances are finished mounting.
+        :type check_stale_element: bool
         :return: None, bool, int, float, string
         """
+        if check_stale_element:
+            # wait in the event element list is actively loading
+            self.controller.wait(
+                timeout=ELEMENTS_GETTER_WAIT_TIME,
+                condition=lambda: [element.text for element in self.get()])
         return [self.controller.js.get_property(element, prop) for element in self.get()]
 
     def set_property(self, prop, value):

--- a/tests/test_component_elements.py
+++ b/tests/test_component_elements.py
@@ -199,6 +199,7 @@ class TestElement(BaseTest):
         """test elements wrapper text aggregation"""
         self.app.wait(timeout=1)  # wait for transitions
         self.assertEqual(len(self.tasks.text()), 3)
+        self.assertEqual(len(self.tasks.text(check_stale_element=True)), 3)
         for task in self.tasks.text():
             self.assertIn('2017', task)
         for task in self.tasks.text(raw=True):
@@ -213,6 +214,7 @@ class TestElement(BaseTest):
         self.assertEqual(len(attributes), 3)
         for attr in attributes:
             self.assertEqual(attr, 'barfoo')
+        self.assertEqual(len(self.tasks.get_attribute('foobar', check_stale_element=True)), 3)
 
     def test_elements_wrapper_properties(self):
         """test elements wrapper property aggregation and specification"""
@@ -223,3 +225,4 @@ class TestElement(BaseTest):
         self.assertEqual(len(properties), 3)
         for prop in properties:
             self.assertEqual(prop, 'barfoo')
+        self.assertEqual(len(self.tasks.get_property('foobar', check_stale_element=True)), 3)


### PR DESCRIPTION
### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

Yes.

2. Can you provide an example of your patch in use?

Not necessary.

3. Is this a breaking change?

No.

#### Content

Provide a short description about what you have changed:

I've added additional flags to Elements getter/scraping methods. The flag is `check_stale_element`, it will default to `False` but when `True` will ensure the given collection of WebElement instances are not stale.

This methodology is not sure proof, but it's as stable as I can possibly make these methods.
