### PR TITLE
Encoded console dump to UTF8 before writing to file. (Issue #101)

### DIFF
--- a/pyscc/controller.py
+++ b/pyscc/controller.py
@@ -291,7 +291,7 @@ class Controller(object):
             log_path = '%sconsole.%s.json' % (path, ('%s.%s' % (name, timestamp)) if \
                 name else timestamp)
             with open(log_path, 'a') as logfile:
-                logfile.write(self.js.console_dump())
+                logfile.write(self.js.console_dump().encode('utf8'))
             return log_path
         except WebDriverException:
             self.logger.critical('Browser logger object not found, could not return any logs.')

--- a/pyscc/controller.py
+++ b/pyscc/controller.py
@@ -18,6 +18,7 @@
 import os
 import logging as logger
 import time
+import sys
 from string import Template
 from types import MethodType
 
@@ -280,7 +281,7 @@ class Controller(object):
         :Warning: `self.js.console_logger` must be executed to store logs.
         :param name: Name log file dropped to disk, will default to timestamp if not specified.
         :type name: string
-        :param path: Path to drop conole log in.
+        :param path: Path to drop console log in.
         :type path: string
         :return: string
         """
@@ -290,9 +291,14 @@ class Controller(object):
             timestamp = str(int(time.time()))
             log_path = '%sconsole.%s.json' % (path, ('%s.%s' % (name, timestamp)) if \
                 name else timestamp)
-            with open(log_path, 'a') as logfile:
-                logfile.write(self.js.console_dump().encode('utf8'))
-            return log_path
+            if sys.version_info[0] < 3:
+                with open(log_path, 'a') as logfile:
+                    logfile.write(self.js.console_dump().encode('utf-8'))
+                return log_path
+            else:
+                with open(log_path, 'a', encoding='utf-8') as logfile:
+                    logfile.write(self.js.console_dump())
+                return log_path
         except WebDriverException:
             self.logger.critical('Browser logger object not found, could not return any logs.')
 

--- a/pyscc/controller.py
+++ b/pyscc/controller.py
@@ -18,7 +18,7 @@
 import os
 import logging as logger
 import time
-import sys
+import io
 from string import Template
 from types import MethodType
 
@@ -291,11 +291,7 @@ class Controller(object):
             timestamp = str(int(time.time()))
             log_path = '%sconsole.%s.json' % (path, ('%s.%s' % (name, timestamp)) if \
                 name else timestamp)
-            if sys.version_info[0] < 3:
-                with open(log_path, 'a') as logfile:
-                    logfile.write(self.js.console_dump().encode('utf-8'))
-                return log_path
-            with open(log_path, 'a', encoding='utf-8') as logfile:
+            with io.open(log_path, 'a', encoding='utf-8') as logfile:
                 logfile.write(self.js.console_dump())
             return log_path
         except WebDriverException:

--- a/pyscc/controller.py
+++ b/pyscc/controller.py
@@ -295,10 +295,9 @@ class Controller(object):
                 with open(log_path, 'a') as logfile:
                     logfile.write(self.js.console_dump().encode('utf-8'))
                 return log_path
-            else:
-                with open(log_path, 'a', encoding='utf-8') as logfile:
-                    logfile.write(self.js.console_dump())
-                return log_path
+            with open(log_path, 'a', encoding='utf-8') as logfile:
+                logfile.write(self.js.console_dump())
+            return log_path
         except WebDriverException:
             self.logger.critical('Browser logger object not found, could not return any logs.')
 


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?
No. This was a simple fix for existing functionality.

2. Can you provide an example of your patch in use?
It's used the same way it was before. The only difference is that UTF-8 characters can be written to the log file.

3. Is this a breaking change?
No. It's a fixing change. :sunglasses: